### PR TITLE
add back deployment bucket

### DIFF
--- a/.dwollaci.yml
+++ b/.dwollaci.yml
@@ -19,7 +19,6 @@ stages:
         . ${NVM_DIR}/nvm.sh --no-use
         nvm install
         ENVIRONMENT=devint \
-        DEPLOYMENT_BUCKET=dwolla-encrypted \
         npm run deploy
   deployUat:
     nodeLabel: nvm-deployer
@@ -30,7 +29,6 @@ stages:
         . ${NVM_DIR}/nvm.sh --no-use
         nvm install
         ENVIRONMENT=uat \
-        DEPLOYMENT_BUCKET=dwolla-encrypted \
         npm run deploy
   deployProd:
     nodeLabel: nvm-deployer
@@ -41,5 +39,4 @@ stages:
         . ${NVM_DIR}/nvm.sh --no-use
         nvm install
         ENVIRONMENT=prod \
-        DEPLOYMENT_BUCKET=dwolla-encrypted \
         npm run deploy

--- a/serverless.js
+++ b/serverless.js
@@ -19,7 +19,10 @@ module.exports = {
     }
   },
   provider: {
-    deploymentBucket: null,
+    deploymentBucket: {
+      name: "dwolla-encrypted",
+      serverSideEncryption: "AES256"
+    },
     environment: {
       AWS_NODEJS_CONNECTION_REUSE_ENABLED: 1,
       SLACK_WEBHOOK_URL: "${ env: SLACK_WEBHOOK_URL }"


### PR DESCRIPTION
Previous build failed with:

```
[2022-09-29T18:13:33.732Z]   Resource ServerlessDeploymentBucket does not exist for stack cloudwatch-alarm-to-slack-devint
```